### PR TITLE
Add custom save method and improve entity handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,5 +21,9 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/datajpa/entity/BaseEntity.java
+++ b/src/main/java/datajpa/entity/BaseEntity.java
@@ -25,6 +25,4 @@ public class BaseEntity implements Serializable {
     private LocalDateTime updatedAt;
     @CreationTimestamp
     private LocalDateTime createdAt;
-    private String createUserId;
-    private String updateUserId;
 }

--- a/src/main/java/datajpa/repository/BaseRepository.java
+++ b/src/main/java/datajpa/repository/BaseRepository.java
@@ -3,10 +3,19 @@ package datajpa.repository;
 import datajpa.entity.BaseEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+
 public interface BaseRepository<T extends BaseEntity> extends JpaRepository<T, String> {
     default T update(T entity){
         T oldEntity = findById(entity.getId()).orElseThrow(() -> new RuntimeException("No updatable user"));
         entity.setCreatedAt(oldEntity.getCreatedAt());
+        entity = saveAndFlush(entity);
+        return entity;
+    }
+    default T save(T entity){
+        LocalDateTime now = LocalDateTime.now();
+        entity.setCreatedAt(now);
+        entity.setUpdatedAt(now);
         entity = saveAndFlush(entity);
         return entity;
     }


### PR DESCRIPTION
Introduced a custom `save` method in `BaseRepository` to set timestamps during entity creation. Removed unused fields `createUserId` and `updateUserId` from `BaseEntity`. Added Jakarta validation dependency to `pom.xml` for future validation support.