### PR TITLE
Add GitHub Maven repository to distribution management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,4 +26,11 @@
             <artifactId>jakarta.validation-api</artifactId>
         </dependency>
     </dependencies>
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub OWNER Apache Maven Packages</name>
+            <url>https://maven.pkg.github.com/bycrafter/data-jpa</url>
+        </repository>
+    </distributionManagement>
 </project>


### PR DESCRIPTION
Configured the `distributionManagement` section in the `pom.xml` to include a GitHub Maven repository. This allows publishing artifacts to GitHub Packages for better dependency management and distribution.